### PR TITLE
Persist pedigree identifier at first rat save

### DIFF
--- a/src/Model/Entity/Rat.php
+++ b/src/Model/Entity/Rat.php
@@ -187,19 +187,19 @@ class Rat extends Entity
         }
     }
 
-    protected function _setPedigreeIdentifier($pedigree_identifier)
-    {
-        if ($this->is_pedigree_custom) {
-            return $pedigree_identifier ;
-        } else if (isset($this->_fields['id']) && isset($this->_fields['rattery'])) {
-            if ($pedigree_identifier == $this->getOriginal('pedigree_identifier')) {
-                $this->setDirty('pedigree_identifier', false);
-            }
-            return $this->rattery->prefix . $this->id . $this->sex ;
-        } else {
-            return '' ; // Should raise an exception
-        }
-    }
+    // protected function _setPedigreeIdentifier($pedigree_identifier)
+    // {
+    //     if ($this->is_pedigree_custom) {
+    //         return $pedigree_identifier ;
+    //     } else if (isset($this->_fields['id']) && isset($this->_fields['rattery'])) {
+    //         if ($pedigree_identifier == $this->getOriginal('pedigree_identifier')) {
+    //             $this->setDirty('pedigree_identifier', true);
+    //         }
+    //         return $this->rattery->prefix . $this->id . $this->sex ;
+    //     } else {
+    //         return '' ; // Should raise an exception
+    //     }
+    // }
 
     protected function _getAge()
     {

--- a/src/Model/Table/IssuesTable.php
+++ b/src/Model/Table/IssuesTable.php
@@ -92,7 +92,7 @@ class IssuesTable extends Table
             'events' => [
                 'Model.beforeSave' => [
                     'created' => 'new',
-                    'closed' => 'always'
+                    'closed' => 'existing'
                 ]
             ]
         ]);


### PR DESCRIPTION
Issue: when pedigree identifier is not "custom", it is not saved at rat creation. Rats with a null pedigree identifier cannot be found by their pedigree identifier in the rat advanced search, and cannot be included in ajax results in selectors (add rat, add litter...)

Fix: write pedigree identifier at creation.

