### PR TITLE
Bugfix in interactive genealogies

### DIFF
--- a/src/Controller/LittersController.php
+++ b/src/Controller/LittersController.php
@@ -264,6 +264,7 @@ class LittersController extends AppController
             'death'=> $dam->short_death_cause . ' (' . $dam->short_age_string . ')',
             'more_parents' => is_null($dam->litter_id) ? 0 : 1,
             '_parents' => [],
+            '_children' => [],
         ]);
 
         array_push($parents,
@@ -277,6 +278,7 @@ class LittersController extends AppController
             'death'=> $sire->short_death_cause . ' (' . $sire->short_age_string . ')',
             'more_parents' => is_null($sire) ? 0 : 1,
             '_parents' => [],
+            '_children' => [],
         ]);
 
         $litter->dam = $dam;

--- a/src/Model/Entity/Rat.php
+++ b/src/Model/Entity/Rat.php
@@ -465,6 +465,7 @@ class Rat extends Entity
                 'death'=> $this->birth_litter->dam[0]->short_death_cause . ' (' . $this->birth_litter->dam[0]->short_age_string . ')',
                 'more_parents' => is_null($this->birth_litter->dam[0]->litter_id) ? 0 : 1,
                 '_parents' => [],
+                '_children' => [],
             ]);
         }
 
@@ -480,6 +481,7 @@ class Rat extends Entity
                 'death'=> $this->birth_litter->sire[0]->short_death_cause . ' (' . $this->birth_litter->sire[0]->short_age_string . ')',
                 'more_parents' => is_null($this->birth_litter->sire[0]->litter_id) ? 0 : 1,
                 '_parents' => [],
+                '_children' => [],
             ]);
         }
         return $parents;


### PR DESCRIPTION
In interactive mode, parents should explicitly have no children (corresponding nodes already exist when they are fetch by ajax) to avoid javascript error.