### PR TITLE
Quickfix on litter pup count with unreliable offspring

### DIFF
--- a/src/Model/Entity/StatisticsTrait.php
+++ b/src/Model/Entity/StatisticsTrait.php
@@ -508,10 +508,13 @@ trait StatisticsTrait
             ->innerJoinWith('OffspringRats')
             ->innerJoinWith('OffspringRats.Ratteries', function ($q) {
                 return $q->where(['Ratteries.is_generic IS' => false]);
-            })
-            ->innerJoinWith('States', function ($q) {
-                return $q->where(['is_reliable IS' => true]);
             });
+
+        if (! isset($options['litter_id']) && $model->associations()->has('States')) {
+            $query = $query->innerJoinWith('States', function ($q) {
+                return $q->where(['States.is_reliable IS' => true]);
+            });
+        }
 
         $females = $query->newExpr()->case()->when(['sex' => 'F'])->then(1, 'integer');
         $males = $query->newExpr()->case()->when(['sex' => 'M'])->then(1, 'integer');

--- a/templates/Litters/add.php
+++ b/templates/Litters/add.php
@@ -210,7 +210,7 @@
                         <?= $this->Form->control('birth_date'); ?>
                     </div>
                     <div class="column-responsive column-50">
-                        <?= $this->Form->control('mating_date', ['empty' => true]); ?>
+                        <?= $this->Form->control('mating_date', ['empty' => true, 'label' => __('Mating date')]); ?>
                     </div>
                 </div>
 


### PR DESCRIPTION
Filtering on States.is_reliable in StatisticsBehaviour (introduced in #161 ) interferred with correct pup count display on litter view, and correct pup count update on rat add. This fix corrects it by removing filtering when counting litter associations.